### PR TITLE
Jasmine Custom Message

### DIFF
--- a/src/spec/part1/app-product-description-selector.projects.spec.ts
+++ b/src/spec/part1/app-product-description-selector.projects.spec.ts
@@ -12,6 +12,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 let productPageComponentExists = false;
 let ProductPageComponent;
+
 try {
   ProductPageComponent = require('../../app/product-page/product-page.component.ts').ProductPageComponent;
   productPageComponentExists = true;
@@ -22,37 +23,54 @@ try {
 let productDescriptionComponentExists = false;
 let ProductDescriptionComponent;
 try {
-  ProductDescriptionComponent = require('../../app/product-description/product-description.component.ts').ProductDescriptionComponent;
+  ProductDescriptionComponent = require('../../app/product-description/product-description.component.ts')
+    .ProductDescriptionComponent;
   productDescriptionComponentExists = true;
 } catch (e) {
   productDescriptionComponentExists = false;
 }
 
 describe('ProductPageComponent', () => {
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [AppModule, RouterTestingModule.withRoutes([])],
-    }).compileComponents();
-  }));
+  beforeEach(
+    async(() => {
+      TestBed.configureTestingModule({
+        imports: [AppModule, RouterTestingModule.withRoutes([])]
+      }).compileComponents();
+    })
+  );
 
-  it(`should contain the app-product-description element @app-product-description-selector`, async(() => {
-    expect(productPageComponentExists).toBe(true);
-    expect(productDescriptionComponentExists).toBe(true);
+  it(
+    `should contain the app-product-description element @app-product-description-selector`,
+    async(() => {
+      since('Here goes a sample custom message to our users, but this test is passing')
+        .expect(productPageComponentExists)
+        .toBe(true);
 
-    const ProductPageFixture = TestBed.createComponent(ProductPageComponent);
-    ProductPageFixture.detectChanges();
+      since('The second expect is the failing expect')
+        .expect(productDescriptionComponentExists)
+        .toBe(true);
 
-    expect(ProductPageFixture.nativeElement.querySelector('app-product-description'));
-  }));
+      const ProductPageFixture = TestBed.createComponent(ProductPageComponent);
+      ProductPageFixture.detectChanges();
 
-  it(`should contain the app-product-description element as a child of the first element with a class of row @app-product-description-selector`, async(() => {
-    expect(productPageComponentExists).toBe(true);
-    expect(productDescriptionComponentExists).toBe(true);
+      since('The third expect is not throwing an error').expect(
+        ProductPageFixture.nativeElement.querySelector('app-product-description')
+      );
+    })
+  );
 
-    const ProductPageFixture = TestBed.createComponent(ProductPageComponent);
-    ProductPageFixture.detectChanges();
-    
-    expect(ProductPageFixture.nativeElement.querySelector('div.row').querySelector('app-product-description').nodeName).toBe('APP-PRODUCT-DESCRIPTION');
-  }));
+  it(
+    `should contain the app-product-description element as a child of the first element with a class of row @app-product-description-selector`,
+    async(() => {
+      expect(productPageComponentExists).toBe(true);
+      expect(productDescriptionComponentExists).toBe(true);
 
+      const ProductPageFixture = TestBed.createComponent(ProductPageComponent);
+      ProductPageFixture.detectChanges();
+
+      expect(
+        ProductPageFixture.nativeElement.querySelector('div.row').querySelector('app-product-description').nodeName
+      ).toBe('APP-PRODUCT-DESCRIPTION');
+    })
+  );
 });

--- a/src/test.ts
+++ b/src/test.ts
@@ -7,10 +7,8 @@ import 'zone.js/dist/jasmine-patch';
 import 'zone.js/dist/async-test';
 import 'zone.js/dist/fake-async-test';
 import { getTestBed } from '@angular/core/testing';
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting
-} from '@angular/platform-browser-dynamic/testing';
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from '@angular/platform-browser-dynamic/testing';
+require('jasmine2-custom-message');
 
 // Unfortunately there's no typing for the `__karma__` variable. Just declare it as any.
 declare var __karma__: any;
@@ -18,22 +16,19 @@ declare var require: any;
 const part = __karma__.config.args[0];
 
 // Prevent Karma from running prematurely.
-__karma__.loaded = function () {};
+__karma__.loaded = function() {};
 
 // First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
-);
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
 
 // load all tests, and then filter into specFiles array if the test path matches the `part#` passed in as an argument into the variable `part`
-const context = require.context('./', true, /projects\.spec\.ts/)
-let specFiles = context.keys().filter((path) => {
-  let filterRegExp = (part) ? new RegExp(part, 'g') : /projects\.spec\.ts/g
-  return filterRegExp.test(path)
-})
+const context = require.context('./', true, /projects\.spec\.ts/);
+let specFiles = context.keys().filter(path => {
+  let filterRegExp = part ? new RegExp(part, 'g') : /projects\.spec\.ts/g;
+  return filterRegExp.test(path);
+});
 
 // and load the modules.
-specFiles.map(context)
+specFiles.map(context);
 // finally, start Karma to run the tests.
 __karma__.start();

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -3,3 +3,6 @@ declare var module: NodeModule;
 interface NodeModule {
   id: string;
 }
+
+// declare the type for since, which is a global name added by jasmine2-custom-message plugin
+declare var since: any;

--- a/tutor-karma.conf.js
+++ b/tutor-karma.conf.js
@@ -2,9 +2,9 @@
 // https://karma-runner.github.io/0.13/config/configuration-file.html
 
 const argv = require('minimist')(process.argv.slice(2)),
-  part = (argv.part !== true) && argv.part;
+  part = argv.part !== true && argv.part;
 
-module.exports = function (config) {
+module.exports = function(config) {
   config.set({
     basePath: '',
     frameworks: ['jasmine', '@angular/cli'],
@@ -16,29 +16,27 @@ module.exports = function (config) {
       require('karma-structured-json-reporter'),
       require('@angular/cli/plugins/karma')
     ],
-    client:{
+    client: {
       args: [part],
       clearContext: false // leave Jasmine Spec Runner output visible in browser
     },
-    files: [
-      { pattern: './src/test.ts', watched: false }
-    ],
+    files: [{ pattern: './src/test.ts', watched: false }],
     preprocessors: {
       './src/test.ts': ['@angular/cli']
     },
+
     mime: {
-      'text/x-typescript': ['ts','tsx']
+      'text/x-typescript': ['ts', 'tsx']
     },
     coverageIstanbulReporter: {
-      reports: [ 'html', 'lcovonly' ],
+      reports: ['html', 'lcovonly'],
       fixWebpackSourcePaths: true
     },
     angularCli: {
       environment: 'dev'
     },
-    reporters: config.angularCli && config.angularCli.codeCoverage
-              ? ['progress', 'coverage-istanbul']
-              : ['json-result'],
+    reporters:
+      config.angularCli && config.angularCli.codeCoverage ? ['progress', 'coverage-istanbul'] : ['json-result'],
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
@@ -46,6 +44,7 @@ module.exports = function (config) {
     browsers: ['PhantomJS'],
     singleRun: false,
     jsonResultReporter: {
+      outputFile: 'karma-result.json',
       isSynchronous: true
     }
   });


### PR DESCRIPTION
This PR adds the `jasmine2-custom-message` module which allows us to write a custom message when using Jasmine. See how you can write the message here:

https://github.com/pluralsight-projects/Angular-AlbumStoreProductPage/blob/610815eb2dec3850fc1fc8c3c8f8806ca7514489/src/spec/part1/app-product-description-selector.projects.spec.ts#L45

I wrote a few messages to guide you in the code above. But what happens is pretty much this:

I added the `since` method to the first `it` block of the first file of part 1.

The first `it` block contains three `expect` methods, where the first and the third `expect` methods do not fail, therefore they don't throw an error.

The second `expect` block will fail and throw the custom message.

The custom message can be verified in the console and in the reporter.

The reporter can be seen inside the `karma-result.json` file.

